### PR TITLE
Package updates

### DIFF
--- a/packages/esling-config-sw-in-fe/package.json
+++ b/packages/esling-config-sw-in-fe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-sw-in-fe",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Eslint and prettier configuration for frontend (react)",
   "author": "Mehul Bechra",
   "main": "index.js",
@@ -15,15 +15,15 @@
     "prettier-config"
   ],
   "peerDependencies": {
-    "eslint": "^7.29.0",
-    "eslint-config-airbnb": "^18.2.1",
-    "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-import": "^2.23.4",
-    "eslint-plugin-jsx-a11y": "^6.4.1",
-    "eslint-plugin-prettier": "^3.4.0",
-    "eslint-plugin-react": "^7.24.0",
-    "eslint-plugin-react-hooks": "^1.7.0",
-    "prettier": "^2.3.2"
+    "eslint": "~8.18.0",
+    "eslint-config-airbnb": "~19.0.4",
+    "eslint-config-prettier": "~8.5.0",
+    "eslint-plugin-import": "~2.26.0",
+    "eslint-plugin-jsx-a11y": "~6.5.1",
+    "eslint-plugin-prettier": "~4.0.0",
+    "eslint-plugin-react": "~7.30.0",
+    "eslint-plugin-react-hooks": "~4.6.0",
+    "prettier": "~2.7.1"
   },
   "repository": {
     "type": "git",

--- a/packages/esling-config-sw-in-fe/prettier.config.js
+++ b/packages/esling-config-sw-in-fe/prettier.config.js
@@ -4,5 +4,6 @@ module.exports = {
   "printWidth": 100,
   "trailingComma": "none",
   "tabWidth": 2,
-  "semi": true
+  "semi": true,
+  "endOfLine": "auto"
 }

--- a/packages/esling-config-sw-in/package.json
+++ b/packages/esling-config-sw-in/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-sw-in",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Eslint and prettier configuration",
   "author": "Mehul Bechra",
   "license": "MIT",
@@ -16,13 +16,13 @@
     "prettier-config"
   ],
   "peerDependencies": {
-    "eslint": "^7.28.0",
-    "eslint-config-airbnb-base": "^14.2.1",
-    "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-import": "^2.23.4",
-    "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-prettier": "^3.4.0",
-    "prettier": "^2.3.1"
+    "eslint": "~8.18.0",
+    "eslint-config-airbnb-base": "~15.0.0",
+    "eslint-config-prettier": "~8.5.0",
+    "eslint-plugin-import": "~2.26.0",
+    "eslint-plugin-node": "~11.1.0",
+    "eslint-plugin-prettier": "~4.0.0",
+    "prettier": "~2.7.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Updated all peer dependencies to latest available versions
- Updated both fe and be package versions to 2.0.0 indicating breaking changes and not allow automatic updates during npm install
- Using endOfLine as auto for frontend package.